### PR TITLE
Return coordinates if a marker is dragged (#207)

### DIFF
--- a/inst/htmlwidgets/lib/map/map_events.js
+++ b/inst/htmlwidgets/lib/map/map_events.js
@@ -111,6 +111,35 @@ function marker_click(map_id, markerObject, marker_id, markerInfo) {
 }
 
 /**
+ * Marker drag
+ *
+ * Returns details of the marker that was dragged
+ **/
+function marker_dragged(map_id, markerObject, marker_id, markerInfo) {
+
+    //'use strict';
+  if (!HTMLWidgets.shinyMode) {
+    return;
+  }
+
+  google.maps.event.addListener(markerObject, 'dragend', function (event) {
+
+    var eventInfo = $.extend(
+      {
+        id: marker_id,
+        lat: event.latLng.lat(),
+        lon: event.latLng.lng(),
+        randomValue: Math.random()
+      },
+      markerInfo
+    ),
+    event_return_type = window.googleway.params[1].event_return_type;
+    eventInfo = event_return_type === "list" ? eventInfo : JSON.stringify(eventInfo);
+    Shiny.onInputChange(map_id + "_marker_drag", eventInfo);
+  });
+}
+
+/**
  * Shape Click
  *
  * Returns the 'id' of the shape that was clicked back to shiny

--- a/inst/htmlwidgets/lib/markers/markers.js
+++ b/inst/htmlwidgets/lib/markers/markers.js
@@ -198,6 +198,7 @@ function set_each_marker(latlon, aMarker, infoWindow, update_map_view, map_id, l
     };
 
     marker_click(map_id, marker, marker.id, markerInfo);
+    marker_dragged(map_id, marker, marker.id, markerInfo);
     window[map_id + 'googleMarkers' + layer_id].push(marker);
     marker.setMap(window[map_id + 'map']);
 }

--- a/tests/manual_tests.R
+++ b/tests/manual_tests.R
@@ -544,6 +544,35 @@
 #
 # shinyApp(ui, server)
 
+# OBSERVING MARKER CLICK AND DRAG
+# ui <- fluidPage(
+#   google_mapOutput(outputId = "map", height = "800px")
+# )
+# server <- function(input, output){
+#   
+#   map_key <- read.dcf("~/Documents/.googleAPI", fields = "GOOGLE_MAP_KEY")
+#   
+#   tram_stops$draggable <- TRUE
+#   
+#   output$map <- renderGoogle_map({
+#       google_map(key = map_key) %>%
+#         add_markers(
+#           data = tram_stops, lat = "stop_lat", lon = "stop_lon",
+#           id = "stop_id",
+#           draggable = "draggable")
+#     })
+#   
+#   observeEvent(input$map_marker_click, {
+#       print("marker clicked")
+#       print(input$map_marker_click)
+#     })
+#   
+#   observeEvent(input$map_marker_drag, {
+#       print("marker dragged")
+#       print(input$map_marker_drag)
+#     })
+# }
+# shinyApp(ui, server)
 
 # OBSERVING MAP EDITS
 # ui <- fluidPage(


### PR DESCRIPTION
This PR solves issue #207 

    - defined marker_dragged() in map_events.js
    - note: I only listen to the 'dragend' event; 'drag' and 'dragstart' could be added as well
    - updated the set_each_marker() function
    - added a manual test