### PR TITLE
`markerColourIconCheck()` fixes error being thrown when allowed colou…

### DIFF
--- a/R/google_map_layer_parameters.R
+++ b/R/google_map_layer_parameters.R
@@ -121,7 +121,7 @@ layerId <- function(layer_id){
 # to be 'icon'
 # @param data the data supplied to the map layer
 # @param objArgs the arguments to the function
-# @param colour Set to `NULL` to not check the clour.  Set to anything other than `NULL`
+# @param colour Set to `NULL` to not check the colour.  Set to anything other than `NULL`
 # to check the colour.
 # @param marker_icon the icon argument for a marker
 markerColourIconCheck <- function(data, objArgs, colour, marker_icon){

--- a/R/google_map_layer_parameters.R
+++ b/R/google_map_layer_parameters.R
@@ -121,7 +121,8 @@ layerId <- function(layer_id){
 # to be 'icon'
 # @param data the data supplied to the map layer
 # @param objArgs the arguments to the function
-# @param colour the colour argument for a marker
+# @param colour Set to `NULL` to not check the clour.  Set to anything other than `NULL`
+# to check the colour.
 # @param marker_icon the icon argument for a marker
 markerColourIconCheck <- function(data, objArgs, colour, marker_icon){
 
@@ -134,7 +135,7 @@ markerColourIconCheck <- function(data, objArgs, colour, marker_icon){
   }
 
   if(!is.null(colour)){
-    if(!all((tolower(data[, colour])) %in% c("red","blue","green","lavender"))){
+    if(!all((tolower(data[["colour"]])) %in% c("red","blue","green","lavender"))){
       stop("colours must be either red, blue, green or lavender")
     }
   }


### PR DESCRIPTION
…rs used

Thanks for the excellent package!  When using one the allowed colours in `add_marker()`, I was running into this error:

```
Warning: Error in : Can't subset columns that don't exist.
x Column `blue` doesn't exist.
```

I traced down the error to the check in the `markerColourIconCheck()` function.  The below PR resolves the above error.  The @param documentation has also been updated to reflect how it looked like the argument was actually being used.  

Just a suggestion -- I would change the argument name to "check_colour" and make it a boolean because the actual string value of the "colour" or NULL is not used in the check; the colours in the "colour" column of data are what is actually checked.  I did not make this change because I wanted to change as little as possible.  Thanks again for great package!